### PR TITLE
Fixed sentinelone_filters example for maintain idempotency

### DIFF
--- a/plugins/modules/sentinelone_filters.py
+++ b/plugins/modules/sentinelone_filters.py
@@ -76,7 +76,8 @@ EXAMPLES = r'''
     site_name: "test"
     name: "MyFilter"
     filter_fields:
-      computerName__contains: "MyComputerName"
+      computerName__contains: 
+        - MyComputerName
       osTypes:
         - windows
 - name: Update filter


### PR DESCRIPTION
This commit fixes https://github.com/svalabs/sva.sentinelone/issues/15 and corrects the usage example for the sentinelone_filters module. The example did not maintain the idempotency.