### PR TITLE
Fixed Ansible Lint Pipeline

### DIFF
--- a/.ansible-lint-ignore
+++ b/.ansible-lint-ignore
@@ -6,7 +6,6 @@ roles/install_agent/vars/Linux.yml var-naming[no-role-prefix]
 roles/install_agent/vars/Windows.yml var-naming[no-role-prefix]
 roles/install_agent/vars/main.yml var-naming[no-role-prefix]
 roles/sentinelone_client_legacy/defaults/main.yml var-naming[no-role-prefix]
-roles/sentinelone_client_legacy/defaults/main.yml var-naming[no-role-prefix]
 roles/sentinelone_client_legacy/tasks/digest.yml command-instead-of-module
 roles/sentinelone_client_legacy/tasks/install_redhat.yml command-instead-of-module
 roles/sentinelone_client_legacy/tasks/install_redhat.yml fqcn[action-core]

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -21,6 +21,8 @@ env:
 jobs:
   ansible-lint:
     uses: ansible/ansible-content-actions/.github/workflows/ansible_lint.yaml@main
+    with:
+      args: "--exclude .ansible/"
   sanity:
     uses: ansible/ansible-content-actions/.github/workflows/sanity.yaml@main
   all_green:

--- a/roles/sentinelone_client_legacy/meta/main.yml
+++ b/roles/sentinelone_client_legacy/meta/main.yml
@@ -1,8 +1,9 @@
+---
 galaxy_info:
-  role_name: sentinelone_client
+  role_name: sentinelone_client_legacy
   author: Christian Stankowic
   description: Installs the SentinelOne agent on linux
-  license: BSD-3-Clause
+  license: GPL-3.0-or-later
 
   min_ansible_version: '2.10'
 


### PR DESCRIPTION
Fixed Ansible Lint Pipeline. The ansible-lint command newly creates a copy of the collection in the .ansible directory. These files got partly checked too. The ansible-lint ignore list didn't match this path. 

Added ignore dir argument to ansible lint pipeline to fix this issue.